### PR TITLE
Nonascii handling

### DIFF
--- a/tradfri-groups.py
+++ b/tradfri-groups.py
@@ -24,6 +24,7 @@
 # pylint: disable=C0200, C0103
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 import ConfigParser

--- a/tradfri-lights.py
+++ b/tradfri-lights.py
@@ -24,6 +24,7 @@
 # pylint: disable=C0200, C0103
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 import ConfigParser

--- a/tradfri-status.py
+++ b/tradfri-status.py
@@ -24,6 +24,7 @@
 # pylint: disable=C0200, C0103
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 import time


### PR DESCRIPTION
Added unicode support for bulb names. Discovered the issue when the original code choked on non-ascii letters in bulb names.