### PR TITLE
configparser for Python3

### DIFF
--- a/tradfri-groups.py
+++ b/tradfri-groups.py
@@ -29,7 +29,12 @@ from __future__ import unicode_literals
 
 import os
 import sys
-import ConfigParser
+
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
+
 import argparse
 
 from tradfri import tradfriActions

--- a/tradfri-lights.py
+++ b/tradfri-lights.py
@@ -29,7 +29,12 @@ from __future__ import unicode_literals
 
 import os
 import sys
-import ConfigParser
+
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
+
 import argparse
 
 from tradfri import tradfriActions

--- a/tradfri-status.py
+++ b/tradfri-status.py
@@ -30,7 +30,11 @@ from __future__ import unicode_literals
 import os
 import sys
 import time
-import ConfigParser
+
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
 
 from tradfri import tradfriStatus
 from tqdm import tqdm


### PR DESCRIPTION
Python3 has renamed ConfigParser to configparser. I do not know if it is a 100% compatible replacement, but this fix it for me.