### PR TITLE
Updating json parse lines

### DIFF
--- a/tradfri/tradfriStatus.py
+++ b/tradfri/tradfriStatus.py
@@ -43,7 +43,7 @@ def tradfri_get_devices(hubip, apiuser, apikey):
         sys.stderr.write('[-] libcoap: could not find libcoap.\n')
         sys.exit(1)
 
-    return json.loads(result.read().strip('\n'))
+    return json.loads(result.read().strip('\n').split('\n')[-1])
 
 def tradfri_get_lightbulb(hubip, apiuser, apikey, deviceid):
     """ function for getting tradfri lightbulb information """
@@ -57,7 +57,7 @@ def tradfri_get_lightbulb(hubip, apiuser, apikey, deviceid):
         sys.stderr.write('[-] libcoap: could not find libcoap.\n')
         sys.exit(1)
 
-    return json.loads(result.read().strip('\n'))
+    return json.loads(result.read().strip('\n').split('\n')[-1])
 
 def tradfri_get_groups(hubip, apiuser, apikey):
     """ function for getting tradfri groups """
@@ -71,7 +71,7 @@ def tradfri_get_groups(hubip, apiuser, apikey):
         sys.stderr.write('[-] libcoap: could not find libcoap.\n')
         sys.exit(1)
 
-    return json.loads(result.read().strip('\n'))
+    return json.loads(result.read().strip('\n').split('\n')[-1])
 
 def tradfri_get_group(hubip, apiuser, apikey, groupid):
     """ function for getting tradfri group information """
@@ -85,4 +85,4 @@ def tradfri_get_group(hubip, apiuser, apikey, groupid):
         sys.stderr.write('[-] libcoap: could not find libcoap.\n')
         sys.exit(1)
 
-    return json.loads(result.read().strip('\n'))
+    return json.loads(result.read().strip('\n').split('\n')[-1])


### PR DESCRIPTION
If the response came with aditional data like:
```
v:1 t:CON c:GET i:9e97 {} [ ]
decrypt_verify(): found 24 bytes cleartext
decrypt_verify(): found 36 bytes cleartext
[65539,65537,65536,65538]
```

it would cause a json parsing error.