### PR TITLE
tradfri-status reports now the warmth value as percentage. 

### DIFF
--- a/tradfri-status.py
+++ b/tradfri-status.py
@@ -66,17 +66,19 @@ def main():
 
     print('[+] Tradfri: device information gathered')
     print('===========================================================\n')
-
     for _ in range(len(lightbulb)):
         try:
+            brightness = lightbulb[_]["3311"][0]["5851"]
+            warmth     = float(lightbulb[_]["3311"][0]["5711"])
+            warmth     = round((warmth-250)/(454-250)*100,1)# reported as a percentage (100% maximum warmth)
             if lightbulb[_]["3311"][0]["5850"] == 0:
-                print('bulb ID {}, name: {}, brightness: {}, state: off'
+                print('bulb ID {0:<5}, name: {1: <35}, brightness: {2: <3}, warmth: {3: >5}%, state: off'
                       .format(lightbulb[_]["9003"], lightbulb[_]["9001"],
-                              lightbulb[_]["3311"][0]["5851"]))
+                              brightness,warmth))
             else:
-                print('bulb ID {}, name: {}, brightness: {}, state: on'
+                print('bulb ID {0:<5}, name: {1: <35}, brightness: {2: <3}, warmth: {3: >5}%, state: on'
                       .format(lightbulb[_]["9003"], lightbulb[_]["9001"],
-                              lightbulb[_]["3311"][0]["5851"]))
+                              brightness,warmth))
         except KeyError:
             # device is not a lightbulb but a remote control, dimmer or sensor
             pass
@@ -85,10 +87,10 @@ def main():
 
     for _ in range(len(lightgroup)):
         if lightgroup[_]["5850"] == 0:
-            print('group ID: {}, name: {}, state: off'
+            print('group ID: {0:<5}, name: {1: <16}, state: off'
                   .format(lightgroup[_]["9003"], lightgroup[_]["9001"]))
         else:
-            print('group ID: {}, name: {}, state: on'
+            print('group ID: {0:<5}, name: {1: <16}, state: on'
                   .format(lightgroup[_]["9003"], lightgroup[_]["9001"]))
 
 if __name__ == "__main__":


### PR DESCRIPTION
improved status readability with fixed-width text fields.

```
bulb ID 65541, name: TRADFRI bulb E27 WS opal 980lm 3   , brightness: 125, warmth: 100.0%, state: off
bulb ID 65538, name: TRADFRI bulb E27 WS opal 980lm     , brightness: 1  , warmth:  73.5%, state: off
bulb ID 65545, name: FLOALT panel WS 30x30 2            , brightness: 254, warmth: 100.0%, state: off
bulb ID 65546, name: FLOALT panel WS 30x30              , brightness: 82 , warmth:  58.8%, state: off
bulb ID 65539, name: TRADFRI bulb E27 WS opal 980lm 2   , brightness: 125, warmth: 100.0%, state: off
```