### PR TITLE
Migrate to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ at this moment there is no coap libs with dTLS, the ikea smart lights are using 
 
 ```bash
 sudo apt-get install automake libtool
-git clone --depth 1 --recursive -b dtls https://github.com/home-assistant/libcoap.git
+git clone https://github.com/obgm/libcoap.git
 cd libcoap
 ./autogen.sh
-./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
+./configure
 make
 sudo make install
 ```

--- a/tradfri-authenticate.py
+++ b/tradfri-authenticate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri-authenticate.py
 # purpose     : authenticate api user and generate configuration file
@@ -13,29 +13,20 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# C0200 -> consider-using-enumerate
-# pylint: disable=C0200, C0103
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
-import time
-import ConfigParser
+import configparser
 
 from tradfri import tradfriActions
 
 def main():
     """ main function """
-    conf = ConfigParser.ConfigParser()
+    conf = configparser.ConfigParser()
     script_dir = os.path.dirname(os.path.realpath(__file__))
     conf.read(script_dir + '/tradfri.cfg')
 
-    hubip = raw_input("\nhub ip:\t\t")
-    securityCode = raw_input("security code: \t")
+    hubip = input("\nhub ip:\t\t")
+    securityCode = input("security code: \t")
 
     print("\n[ ] acquiring api key ...", end="")
 

--- a/tradfri-groups.py
+++ b/tradfri-groups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri-groups.py
 # purpose     : controlling status from the Ikea tradfri smart groups
@@ -19,17 +19,9 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# C0200 -> consider-using-enumerate
-# pylint: disable=C0200, C0103
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
-import ConfigParser
+import configparser
 import argparse
 
 from tradfri import tradfriActions
@@ -50,7 +42,7 @@ def parse_args():
 def main():
     """ main function """
     args = parse_args()
-    conf = ConfigParser.ConfigParser()
+    conf = configparser.ConfigParser()
     script_dir = os.path.dirname(os.path.realpath(__file__))
     conf.read(script_dir + '/tradfri.cfg')
 

--- a/tradfri-lights.py
+++ b/tradfri-lights.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri-lights.py
 # purpose     : getting status from the Ikea tradfri smart lights
@@ -19,17 +19,9 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# C0200 -> consider-using-enumerate
-# pylint: disable=C0200, C0103
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
-import ConfigParser
+import configparser
 import argparse
 from textwrap import wrap
 
@@ -52,7 +44,7 @@ def parse_args():
 def main():
     """ main function """
     args = parse_args()
-    conf = ConfigParser.ConfigParser()
+    conf = configparser.ConfigParser()
     script_dir = os.path.dirname(os.path.realpath(__file__))
     conf.read(script_dir + '/tradfri.cfg')
 

--- a/tradfri-status.py
+++ b/tradfri-status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri-status.py
 # purpose     : getting status from the Ikea tradfri smart lights
@@ -19,25 +19,17 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# C0200 -> consider-using-enumerate
-# pylint: disable=C0200, C0103
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import sys
 import time
-import ConfigParser
+import configparser
 
 from tradfri import tradfriStatus
 from tqdm import tqdm
 
 def main():
     """ main function """
-    conf = ConfigParser.ConfigParser()
+    conf = configparser.ConfigParser()
     script_dir = os.path.dirname(os.path.realpath(__file__))
     conf.read(script_dir + '/tradfri.cfg')
 

--- a/tradfri/tradfriActions.py
+++ b/tradfri/tradfriActions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri/tradfriActions.py
 # purpose     : module for controling status of the Ikea tradfri smart lights
@@ -19,18 +19,13 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# pylint: disable=C0103
-
 import sys
-import os
 import json
 import random
-from tradfriStatus import tradfri_get_lightbulb
+import subprocess
+from .tradfriStatus import tradfri_get_lightbulb
 
-global coap
-coap = '/usr/local/bin/coap-client'
+coap = 'coap-client'
 
 def tradfri_power_light(hubip, apiuser, apikey, lightbulbid, value):
     """ function for power on/off tradfri lightbulb """
@@ -44,11 +39,7 @@ def tradfri_power_light(hubip, apiuser, apikey, lightbulbid, value):
     api = '{} -m put -u "{}" -k "{}" -e \'{}\' "{}"' .format(coap, apiuser, apikey,
                                                                           payload, tradfriHub)
 
-    if os.path.exists(coap):
-        os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+    subprocess.check_output(api, shell=True)
 
     return True
 
@@ -62,11 +53,7 @@ def tradfri_dim_light(hubip, apiuser, apikey, lightbulbid, value):
     api = '{} -m put -u "{}" -k "{}" -e \'{}\' "{}"'.format(coap, apiuser, apikey,
                                                                          payload, tradfriHub)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
     return result
 
@@ -90,11 +77,8 @@ def tradfri_color_light(hubip, apiuser, apikey, lightbulbid, value):
 
     api = '{} -m put -u "{}" -k "{}" -e \'{}\' "{}"'.format(coap, apiuser, apikey,
                                                                          payload, tradfriHub)
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+
+    result = subprocess.check_output(api, shell=True)
 
     return result
 
@@ -110,11 +94,7 @@ def tradfri_power_group(hubip, apiuser, apikey, groupid, value):
     api = '{} -m put -u "{}" -k "{}" -e \'{}\' "{}"' .format(coap, apiuser, apikey,
                                                                           payload, tradfriHub)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
     return result
 
@@ -128,11 +108,7 @@ def tradfri_dim_group(hubip, apiuser, apikey, groupid, value):
     api = '{} -m put -u "{}" -k "{}" -e \'{}\' "{}"'.format(coap, apiuser, apikey,
                                                                          payload, tradfriHub)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
     return result
 
@@ -144,14 +120,10 @@ def tradfri_authenticate(hubip, securitycode, apiuser = "TRADFRI_PY_API_" + str(
     api = '{} -m post -u "Client_identity" -k "{}" -e \'{}\' "{}"'.format(coap, securitycode,
                                                                          payload, tradfriHub)
                                                                          
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
     try:
-        apikey = json.loads(result.read().strip('\n').split('\n')[-1])["9091"]
+        apikey = json.loads(result.decode().strip('\n').split('\n')[-1])["9091"]
     except ValueError:
         raise Exception("Didn't receive valid apikey. This is because the api isn't reachable or the api user already exists.")
 

--- a/tradfri/tradfriStatus.py
+++ b/tradfri/tradfriStatus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # file        : tradfri/tradfriStatus.py
 # purpose     : getting status from the Ikea tradfri smart lights
@@ -19,16 +19,10 @@
     that supports coap with dTLS. see ../bin/README how to compile libcoap with dTLS support
 """
 
-# pylint convention disablement:
-# C0103 -> invalid-name
-# pylint: disable=C0103
-
-import sys
-import os
 import json
+import subprocess
 
-global coap
-coap = '/usr/local/bin/coap-client'
+coap = 'coap-client'
 timeout = 5
 
 def tradfri_get_devices(hubip, apiuser, apikey):
@@ -37,13 +31,9 @@ def tradfri_get_devices(hubip, apiuser, apikey):
     api = '{} -m get -u "{}" -k "{}" "{}" -B {} 2> /dev/null' .format(coap, apiuser, apikey,
                                                                       tradfriHub, timeout)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap.\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
-    return json.loads(result.read().strip('\n').split('\n')[-1])
+    return json.loads(result.decode().strip('\n').split('\n')[-1])
 
 def tradfri_get_lightbulb(hubip, apiuser, apikey, deviceid):
     """ function for getting tradfri lightbulb information """
@@ -51,13 +41,9 @@ def tradfri_get_lightbulb(hubip, apiuser, apikey, deviceid):
     api = '{} -m get -u "{}" -k "{}" "{}" -B {} 2> /dev/null' .format(coap, apiuser, apikey,
                                                                       tradfriHub, timeout)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap.\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
-    return json.loads(result.read().strip('\n').split('\n')[-1])
+    return json.loads(result.decode().strip('\n').split('\n')[-1])
 
 def tradfri_get_groups(hubip, apiuser, apikey):
     """ function for getting tradfri groups """
@@ -65,13 +51,9 @@ def tradfri_get_groups(hubip, apiuser, apikey):
     api = '{} -m get -u "{}" -k "{}" "{}" -B {} 2> /dev/null' .format(coap, apiuser, apikey,
                                                                       tradfriHub, timeout)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap.\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
-    return json.loads(result.read().strip('\n').split('\n')[-1])
+    return json.loads(result.decode().strip('\n').split('\n')[-1])
 
 def tradfri_get_group(hubip, apiuser, apikey, groupid):
     """ function for getting tradfri group information """
@@ -79,10 +61,6 @@ def tradfri_get_group(hubip, apiuser, apikey, groupid):
     api = '{} -m get -u "{}" -k "{}" "{}" -B {} 2> /dev/null' .format(coap, apiuser, apikey,
                                                                       tradfriHub, timeout)
 
-    if os.path.exists(coap):
-        result = os.popen(api)
-    else:
-        sys.stderr.write('[-] libcoap: could not find libcoap.\n')
-        sys.exit(1)
+    result = subprocess.check_output(api, shell=True)
 
-    return json.loads(result.read().strip('\n').split('\n')[-1])
+    return json.loads(result.decode().strip('\n').split('\n')[-1])


### PR DESCRIPTION
Changes:

* Recommend the official [obgm/libcoap](https://github.com/obgm/libcoap) fork, which has dtls support
* use `coap-client` from PATH instead of hard-coded `/usr/local/bin/coap-client`
* `os.popen()` -> `subprocess.check_output()`: this also checks for nonzero return code, for instance if the coap executable isn't found (no need to manually check)
* `ConfigParser` -> `configparser`
* `raw_input()` -> `input()`